### PR TITLE
add "rename" option, bump nunjucks dep to 1.0.0 to fix runtime error

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,12 @@ Type: `Boolean` (default: `false`)
 Compile each template as a callable function. Use this if you want to
 compile each template file into a separate js file as a simple
 callable object.
+
+#### options.rename
+Type: `function(filepath) : string` (optional)
+
+If present, this function is called once per template file.  It is passed
+the filepath of the template and should return a name for the compiled
+template.
+
+If this option isn't present, the filepath will be the name of the template.

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-watch": "~0.5.3"
-    "nunjucks": "~0.1.10"
+    "grunt-contrib-watch": "~0.5.3",
+    "nunjucks": "~1.0.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.1",
-    "nunjucks": ">=0.1.10"
+    "nunjucks": ">=1.0.0"
   },
   "keywords": [
     "gruntplugin"

--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -27,7 +27,14 @@ module.exports = function(grunt) {
                     return true;
                 }
             }).map(function(filepath) {
-                return nunjucks.precompile(filepath, opts);
+                var precompileOpts = {
+                    asFunction: opts.asFunction,
+                    env: opts.env
+                };
+                if (opts.rename) {
+                    precompileOpts.name = opts.rename(filepath);
+                }
+                return nunjucks.precompile(filepath, precompileOpts);
             }).join('');
 
             grunt.file.write(f.dest, src);


### PR DESCRIPTION
## add "rename" option

This adds a task option `rename` that is called once per template file and used to populate the `name` option to `precompile`.

Example:

```
var path = require('path');
...
nunjucks: {
  precompile: {
    options: {
      rename: function(src) {
         return path.basename(src);
      },
  },
```
## bump nunjucks dep to 1.0.0 to fix runtime error

Before upgrading Nunjucks to 1.0.0, I was hitting the following error:

![screen shot 2013-10-29 at 4 29 53 pm](https://f.cloud.github.com/assets/1527302/1433475/262d4b82-40f5-11e3-9881-8ae59cd28ead.png)
