### PR TITLE
Fix ``baseDir`` setting to strip baseDir from filepath.

### DIFF
--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
                     return true;
                 }
             }).map(function(filepath) {
+                var filename = filepath;
                 if (f.baseDir) {
                     if (f.baseDir.substr(-1) !== '/') {
                         // Append a trailing slash, if there isn't one.
@@ -39,10 +40,10 @@ module.exports = function (grunt) {
                     }
                     if (filepath.substr(0, f.baseDir.length) === f.baseDir) {
                         // Strip leading `baseDir` from filename.
-                        opts.name = filepath.substr(f.baseDir.length);
+                        filename = filepath.substr(f.baseDir.length);
                     }
                 }
-                opts.name = nameFunc(filepath);
+                opts.name = nameFunc(filename);
                 return nunjucks.precompile(filepath, opts);
             }).join('');
 

--- a/tasks/output/templates.js
+++ b/tasks/output/templates.js
@@ -1,4 +1,4 @@
-(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["tasks/views/bar.html"] = (function() {function root(env, context, frame, runtime, cb) {
+(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["bar.html"] = (function() {function root(env, context, frame, runtime, cb) {
 var lineno = null;
 var colno = null;
 var output = "";
@@ -17,7 +17,7 @@ root: root
 };
 })();
 })();
-(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["tasks/views/foo.html"] = (function() {function root(env, context, frame, runtime, cb) {
+(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["foo.html"] = (function() {function root(env, context, frame, runtime, cb) {
 var lineno = null;
 var colno = null;
 var output = "";
@@ -36,7 +36,7 @@ root: root
 };
 })();
 })();
-(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["tasks/views/index.html"] = (function() {function root(env, context, frame, runtime, cb) {
+(function() {(window.nunjucksPrecompiled = window.nunjucksPrecompiled || {})["index.html"] = (function() {function root(env, context, frame, runtime, cb) {
 var lineno = null;
 var colno = null;
 var output = "";


### PR DESCRIPTION
Unless I'm missing something, it seems the `baseDir` setting currently doesn't actually do anything, because `opts.name` gets reset by the `nameFunc` fn regardless of `baseDir`. This PR fixes that.

Thanks for a great templating language and grunt plugin!
