### PR TITLE
Fix strip leading `baseDir` from filename

### DIFF
--- a/tasks/nunjucks.js
+++ b/tasks/nunjucks.js
@@ -32,6 +32,8 @@ module.exports = function (grunt) {
                     return true;
                 }
             }).map(function(filepath) {
+                var baseName;
+                
                 if (f.baseDir) {
                     if (f.baseDir.substr(-1) !== '/') {
                         // Append a trailing slash, if there isn't one.
@@ -39,10 +41,10 @@ module.exports = function (grunt) {
                     }
                     if (filepath.substr(0, f.baseDir.length) === f.baseDir) {
                         // Strip leading `baseDir` from filename.
-                        opts.name = filepath.substr(f.baseDir.length);
+                        baseName = filepath.substr(f.baseDir.length);
                     }
                 }
-                opts.name = nameFunc(filepath);
+                opts.name = nameFunc(baseName || filepath);
                 return nunjucks.precompile(filepath, opts);
             }).join('');
 


### PR DESCRIPTION
When you were stripping the leading `baseDir` from filename you were saving in a variable that is no longer read, so the `baseDir` config was not working.
